### PR TITLE
Future-proof iOS version check.

### DIFF
--- a/ios-drag-drop.js
+++ b/ios-drag-drop.js
@@ -7,7 +7,7 @@
   function main(config) {
     config = config || {};
 
-    coordinateSystemForElementFromPoint = navigator.userAgent.match(/OS 5(?:_\d+)+ like Mac/) ? "client" : "page";
+    coordinateSystemForElementFromPoint = navigator.userAgent.match(/OS [1-4](?:_\d+)+ like Mac/) ? "page" : "client";
 
     var div = doc.createElement('div');
     var dragDiv = 'draggable' in div;


### PR DESCRIPTION
The current iOS version detection works great up to iOS 5, but anything higher will not match and will be given the incorrect coordinates for their implementations of _elementFromPoint_. As it can be assumed that there will be new versions of iOS for at least as long as this shim is required, it makes much more sense to correct the behavior of older (and presently fully enumerated) versions instead.
