### PR TITLE
Properly check whether the draggable attribute is true.

### DIFF
--- a/ios-drag-drop.js
+++ b/ios-drag-drop.js
@@ -198,7 +198,7 @@
   function touchstart(evt) {
     var el = evt.target;
     do {
-      if (el.getAttribute("draggable") == "true") {
+      if (el.draggable === true) {
         evt.preventDefault();
         new DragDrop(evt,el);
       }


### PR DESCRIPTION
Checking whether an element has the `draggable` attribute does not provide the correct behavior. The `draggable` attribute can be present with the value `false`. This patch correctly handles such cases.

See [The Draggable Attribute](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Drag_operations#draggableattribute)
