### PR TITLE
Add the types property to the DataTransfer object.

### DIFF
--- a/ios-drag-drop.js
+++ b/ios-drag-drop.js
@@ -29,6 +29,7 @@
 
     this.touchPositions = {};
     this.dragData = {};
+    this.dragDataTypes = [];
     this.el = el || event.target
 
     event.preventDefault();
@@ -55,6 +56,7 @@
       function cleanup() {
         log("cleanup");
         this.touchPositions = {};
+        this.dragDataTypes = [];
         this.el = this.dragData = null;
         return [move, end, cancel].forEach(function(handler) {
           return handler.off();
@@ -125,6 +127,7 @@
       var dropEvt = doc.createEvent("Event");
       dropEvt.initEvent("drop", true, true);
       dropEvt.dataTransfer = {
+        types: this.dragDataTypes,
         getData: function(type) {
           return this.dragData[type];
         }.bind(this)
@@ -149,6 +152,7 @@
       var enterEvt = doc.createEvent("Event");
       enterEvt.initEvent("dragenter", true, true);
       enterEvt.dataTransfer = {
+        types: this.dragDataTypes,
         getData: function(type) {
           return this.dragData[type];
         }.bind(this)
@@ -161,6 +165,7 @@
       var leaveEvt = doc.createEvent("Event");
       leaveEvt.initEvent("dragleave", true, true);
       leaveEvt.dataTransfer = {
+        types: this.dragDataTypes,
         getData: function(type) {
           return this.dragData[type];
         }.bind(this)
@@ -186,6 +191,9 @@
       evt.dataTransfer = {
         setData: function(type, val) {
           this.dragData[type] = val;
+          if (this.dragDataTypes.indexOf(type) == -1) {
+            this.dragDataTypes[this.dragDataTypes.length] = type;
+          }
           return val;
         }.bind(this),
         dropEffect: "move"


### PR DESCRIPTION
This patch takes another step closer to functional parity with HTML5 drag & drop by adding support for the `types` property of the `DataTransfer` object. This `types` property is an ordered list of all the data types that were set with the `setData` method, in the order that they were first added.

See [types](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer#types.28.29)
