### PR TITLE
Fixing interaction with vanilla links.

### DIFF
--- a/ios-drag-drop.js
+++ b/ios-drag-drop.js
@@ -242,6 +242,17 @@
     var el = evt.target;
     do {
       if (el.draggable === true) {
+        // If draggable isn't explicitly set for anchors, then simulate a click event.
+        // Otherwise plain old vanilla links will stop working.
+        // https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Touch_events#Handling_clicks
+        if (!el.hasAttribute("draggable") && el.tagName.toLowerCase() == "a") {
+          var clickEvt = document.createEvent("MouseEvents");
+          clickEvt.initMouseEvent("click", true, true, el.ownerDocument.defaultView, 1,
+            evt.screenX, evt.screenY, evt.clientX, evt.clientY,
+            evt.ctrlKey, evt.altKey, evt.shiftKey, evt.metaKey, 0, null);
+          el.dispatchEvent(clickEvt);
+          log("Simulating click to anchor");
+        }
         evt.preventDefault();
         new DragDrop(evt,el);
       }


### PR DESCRIPTION
With pull request #18 we started properly checking whether an element is draggable. However, because anchors are draggable by default, we ended up with an interesting regression bug. Links don't work anymore.

As we call the `preventDefault()` method on our `touchstart` event, the browser will no longer generate a `click` event. In general this is the expected behavior for HTML5 drag & drop. However the browsers initiate their native drag handling only in special cases, when the mouse is moved a certain amount after being pressed down. Without sufficient movement, it's handled as a classic click.

Ideally we would like to have similar handling via `touchmove` and fallback to clicks without enough movement, however I've cooked up a faster fix for now.

With this patch, anchors are still draggable by default and handled as such. However if an anchor element doesn't have the `draggable` attribute explicitly set, then we also simulate a `click` event.

This means a rather sane default where plain old anchor elements like `<a href="/">Home</a>` will actually work as links, while also allowing people to disable this `click` simulation by adding an explicit `draggable` attribute like `<a href="/" draggable="true">Home</a>`.
