### PR TITLE
add transform to potential conflict attributes

### DIFF
--- a/src/internal/dom-utils.ts
+++ b/src/internal/dom-utils.ts
@@ -53,6 +53,7 @@ function prepareNodeCopyAsDragImage( srcNode:HTMLElement, dstNode:HTMLElement ) 
         dstNode.style.pointerEvents = "none";
 
         // Remove any potential conflict attributes
+        dstNode.style.transform = "";
         dstNode.removeAttribute( "id" );
         dstNode.removeAttribute( "class" );
         dstNode.removeAttribute( "draggable" );


### PR DESCRIPTION
Hi @timruffles,
Have a use case where the items I want to drag already have transform on they're style, making the transform empty string fixes my issue of having the image outside the view port.