### PR TITLE
Bugfix for issue #131

### DIFF
--- a/src/scroll-behaviour.ts
+++ b/src/scroll-behaviour.ts
@@ -50,16 +50,7 @@ function getElementViewportOffset( el:HTMLElement, axis:ScrollAxis ) {
 }
 
 function getElementViewportSize( el:HTMLElement, axis:ScrollAxis ) {
-    let size:number;
-
-    if( isTopLevelEl( el ) ) {
-        size = (axis === ScrollAxis.HORIZONTAL) ? window.innerWidth : window.innerHeight;
-    }
-    else {
-        size = (axis === ScrollAxis.HORIZONTAL) ? el.clientWidth : el.clientHeight;
-    }
-
-    return size;
+    return (axis === ScrollAxis.HORIZONTAL) ? el.clientWidth : el.clientHeight;
 }
 
 function getSetElementScroll( el:HTMLElement, axis:ScrollAxis, scroll?:number ) {
@@ -88,14 +79,25 @@ function getSetElementScroll( el:HTMLElement, axis:ScrollAxis, scroll?:number ) 
 
 //TODO check if scroll end is reached according to scroll intention? this is needed to implement scroll chaining
 function isScrollable( el:HTMLElement ):boolean {
-    const cs = getComputedStyle( el );
 
-    if( el.scrollHeight > el.clientHeight && (cs.overflowY === "scroll" || cs.overflowY === "auto") ) {
-        return true;
+    if( el.scrollHeight > el.clientHeight ) {
+
+        if( el === document.documentElement ) {
+            return true;
+        }
+
+        const cs = getComputedStyle( el );
+        return cs.overflowY === "scroll" || cs.overflowY === "auto";
     }
 
-    if( el.scrollWidth > el.clientWidth && (cs.overflowX === "scroll" || cs.overflowX === "auto") ) {
-        return true;
+    if( el.scrollWidth > el.clientWidth ) {
+
+        if( el === document.documentElement ) {
+            return true;
+        }
+
+        const cs = getComputedStyle( el );
+        return cs.overflowX === "scroll" || cs.overflowX === "auto";
     }
 
     return false;
@@ -194,6 +196,7 @@ let _currentCoordinates:Point;
 let _hoveredElement:HTMLElement;
 let _scrollableParent:HTMLElement;
 let _translateDragImageFn:( offsetX:number, offsetY:number ) => void;
+let _scrollableParentBounds:IScrollBounds;
 
 /**
  * core handler function
@@ -297,44 +300,44 @@ function updateScrollIntentions( currentCoordinates:Point,
         // when coordinates become undefined drag operation stopped. stop scrolling also.
         return false;
     }
-
-    const scrollableParentBounds:IScrollBounds = {
+    const updateScrollWidth:boolean = _scrollableParentBounds === undefined || _scrollableParentBounds.scrollWidth === undefined || scrollableParent === undefined;
+    const updateScrollHeight:boolean = _scrollableParentBounds === undefined || _scrollableParentBounds.scrollHeight === undefined || scrollableParent === undefined;
+        _scrollableParentBounds = {
         x: getElementViewportOffset( scrollableParent, ScrollAxis.HORIZONTAL ),
         y: getElementViewportOffset( scrollableParent, ScrollAxis.VERTICAL ),
         width: getElementViewportSize( scrollableParent, ScrollAxis.HORIZONTAL ),
         height: getElementViewportSize( scrollableParent, ScrollAxis.VERTICAL ),
         scrollX: getSetElementScroll( scrollableParent, ScrollAxis.HORIZONTAL ),
         scrollY: getSetElementScroll( scrollableParent, ScrollAxis.VERTICAL ),
-        scrollWidth: scrollableParent.scrollWidth,
-        scrollHeight: scrollableParent.scrollHeight
+        scrollWidth: updateScrollWidth ? scrollableParent.scrollWidth : _scrollableParentBounds.scrollWidth,
+        scrollHeight: updateScrollHeight ? scrollableParent.scrollHeight : _scrollableParentBounds.scrollHeight
     };
-
     const currentCoordinatesOffset = {
-        x: currentCoordinates.x - scrollableParentBounds.x,
-        y: currentCoordinates.y - scrollableParentBounds.y
+        x: currentCoordinates.x - _scrollableParentBounds.x,
+        y: currentCoordinates.y - _scrollableParentBounds.y
     };
 
-    scrollIntentions.horizontal = determineScrollIntention( currentCoordinatesOffset.x, scrollableParentBounds.width, threshold );
-    scrollIntentions.vertical = determineScrollIntention( currentCoordinatesOffset.y, scrollableParentBounds.height, threshold );
+    scrollIntentions.horizontal = determineScrollIntention( currentCoordinatesOffset.x, _scrollableParentBounds.width, threshold );
+    scrollIntentions.vertical = determineScrollIntention( currentCoordinatesOffset.y, _scrollableParentBounds.height, threshold );
 
-    if( scrollIntentions.horizontal && isScrollEndReached( ScrollAxis.HORIZONTAL, scrollIntentions.horizontal, scrollableParentBounds ) ) {
+    if( scrollIntentions.horizontal && isScrollEndReached( ScrollAxis.HORIZONTAL, scrollIntentions.horizontal, _scrollableParentBounds ) ) {
 
         // if scroll end is reached, reset to none
         scrollIntentions.horizontal = ScrollIntention.NONE;
     }
     else if( scrollIntentions.horizontal ) {
 
-        dynamicVelocity.x = determineDynamicVelocity( scrollIntentions.horizontal, currentCoordinatesOffset.x, scrollableParentBounds.width, threshold );
+        dynamicVelocity.x = determineDynamicVelocity( scrollIntentions.horizontal, currentCoordinatesOffset.x, _scrollableParentBounds.width, threshold );
     }
 
-    if( scrollIntentions.vertical && isScrollEndReached( ScrollAxis.VERTICAL, scrollIntentions.vertical, scrollableParentBounds ) ) {
+    if( scrollIntentions.vertical && isScrollEndReached( ScrollAxis.VERTICAL, scrollIntentions.vertical, _scrollableParentBounds ) ) {
 
         // if scroll end is reached, reset to none
         scrollIntentions.vertical = ScrollIntention.NONE;
     }
     else if( scrollIntentions.vertical ) {
 
-        dynamicVelocity.y = determineDynamicVelocity( scrollIntentions.vertical, currentCoordinatesOffset.y, scrollableParentBounds.height, threshold );
+        dynamicVelocity.y = determineDynamicVelocity( scrollIntentions.vertical, currentCoordinatesOffset.y, _scrollableParentBounds.height, threshold );
     }
 
     return !!(scrollIntentions.horizontal || scrollIntentions.vertical);


### PR DESCRIPTION
This fixes the scroll behaviour issues on body elements without fixed height. Tested with the minimal example given in the issue and the default demo of the polyfill.
The fix is based on three main changes:

1. `isScrollable` will always return true, if `scrollableParent` is `document.documentElement` as mentioned in the comments by @reppners 
2. `getElementViewportSize()` now returns `Math.min` of `el.clientWidth` and `window.innerWidth` or `el.clientHeight` `window.innerHeight` respectively.
3. `_scrollableParentBounds` are moved outside the function's scope to make it possible to only update `scrollWidth`/`scrollHeight` of `_scrollableParentBounds`  if the `scrollableParent` changes.

I hope this fix is solid enough to make it into the next release and doesn't break any other behaviour.