### PR TITLE
fix:transition-duration attributes filter in prepareNodeCopyAsDragImage

### DIFF
--- a/src/internal/dom-utils.ts
+++ b/src/internal/dom-utils.ts
@@ -43,6 +43,13 @@ function prepareNodeCopyAsDragImage( srcNode:HTMLElement, dstNode:HTMLElement ) 
         const cs = getComputedStyle( srcNode );
         for( let i = 0; i < cs.length; i++ ) {
             const csName = cs[ i ];
+            
+            // transition-duration cause the dragging animation delay.
+            if ( csName === "transition-duration" ) {
+                dstNode.style.setProperty( csName, "0s", "" );
+                continue;
+            }
+            
             dstNode.style.setProperty( csName, cs.getPropertyValue( csName ), cs.getPropertyPriority( csName ) );
         }
 


### PR DESCRIPTION
link-issue: https://github.com/timruffles/mobile-drag-drop/issues/163
solve-problem: transition-duration cause the dragging animation delay which should be set to 0s as default during the dragging;
finally, thanks this great repo . save my time!
