### PR TITLE
Bugfix #173 - Guard against possible falsy node.children values

### DIFF
--- a/src/internal/dom-utils.ts
+++ b/src/internal/dom-utils.ts
@@ -85,7 +85,7 @@ function removePointerEventsFromShadoDomChildNodes( node:Element ) {
     if (node instanceof HTMLElement) {
         node.style.pointerEvents = "none";
     }
-    if ( node.children.length ) {
+    if ( node.children && node.children.length ) {
         for( let i = 0; i < node.children.length; i++ ) {
             removePointerEventsFromShadoDomChildNodes(node.children[ i ]);
         }


### PR DESCRIPTION
The purpose of this PR is to add a check against undefined values when checking for node children within the `removePointerEventsFromShadoDomChildNodes` function.

Unfortunately, I don't have a way of reproducing this yet, but I tracked down the error mentioned in #173 to this. Using this patch fixes the issue for me.

This should fix #173.