### PR TITLE
fix touch detection is not accurate

### DIFF
--- a/src/internal/feature-detection.ts
+++ b/src/internal/feature-detection.ts
@@ -16,7 +16,7 @@ export function detectFeatures():DetectedFeatures {
             (/iPad|iPhone|iPod|Android/.test(navigator.userAgent))
             || // OR
             //if is blink(chrome/opera) with touch events enabled -> no native dnd
-            (isBlinkEngine && ("ontouchstart" in document.documentElement))
+            (isBlinkEngine && navigator.maxTouchPoints > 0)
         )
     };
 }


### PR DESCRIPTION
`("ontouchstart" in document.documentElement)` will return false on Desktop Chrome even if it support touch. 

Refer to other repo, they use `navigator.maxTouchPoints > 0` to detect if the device supports touch.
https://github.com/microsoft/vscode/blob/f873eb102260dcbdd0c4068a59f21c1ef91697bd/src/vs/base/browser/touch.ts#L127C3-L127C3

the [demo](https://www.timr.co/mobile-drag-drop/demo/) also does not work on Desktop Chrome with a touch device. I've tried it on other browsers, and this way is more accurate.

also check [caniuse](https://caniuse.com/mdn-api_navigator_maxtouchpoints):
![Screenshot 2024-01-05 at 9 40 47 AM](https://github.com/timruffles/mobile-drag-drop/assets/47012/d664dd74-60a9-49fe-b25d-9aa9c64ed611)
