### PR TITLE
feat: add clearPolyfill

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { addDocumentListener, createDragImage, onEvt, Point } from "./internal/dom-utils";
+import { addDocumentListener, createDragImage, onEvt, Point, removeDocumentListener } from "./internal/dom-utils";
 import { DragOperationController, DragOperationState } from "./internal/drag-operation-controller";
 import { elementFromPoint, tryFindDraggableTarget } from "./internal/drag-utils";
 import { detectFeatures } from "./internal/feature-detection";
@@ -230,6 +230,14 @@ export function polyfill( override?:Config ):boolean {
     }
 
     return true;
+}
+
+export function clearPolyfill(): void {
+    if( config.holdToDrag ) {
+        removeDocumentListener("touchstart", onDelayTouchstart);
+    } else {
+        removeDocumentListener("touchstart", onTouchstart);
+    }
 }
 
 //</editor-fold>


### PR DESCRIPTION
may resolves https://github.com/timruffles/mobile-drag-drop/issues/147

I'd like to do the same as in the issue: turn on this plugin only in one page but not in others.
As `polyfill()` just adds event listener and everything else is inside the event handler, adding the event listener on page load and removing it on page leave can achieve that. 
I'm not sure `clearPolyfill` is proper term and any comments are welcome.

